### PR TITLE
improve uri resolver and add _ref functions for non-rust wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cifs-client"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 description = "A minimal, Rust-native CIFS client implementation"

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ impl fmt::Display for Error {
             Error::FrameTooBig => write!(f, "frame exceeds maximal size"),
             Error::UnexpectedReply(want,got) => write!(f, "unexpected reply, want: {:?}, got: {:?}", want, got),
             Error::TooManyReplies(num) => write!(f, "we expect one reply but got {}", num),
-            Error::ServerError(status) => write!(f, "server reports error: {}", status),
+            Error::ServerError(status) => write!(f, "server error: {}", status),
             Error::Unsupported(what) => write!(f, "unsupported feature: {}", what),
             Error::InvalidUri => write!(f, "URI is invalid"),
         }

--- a/src/smb/msg.rs
+++ b/src/smb/msg.rs
@@ -368,7 +368,7 @@ impl Close {
         }
     }
 
-    pub fn handle(file: Handle) -> Self {
+    pub fn handle(file: &Handle) -> Self {
         Self::new(file.tid, file.fid)
     }
 }


### PR DESCRIPTION
The improved URI resolver now supports user, password and domain and returns a CifsConfig instead of a tuple.

Added mount_ref and close_ref, which don't consume their argument for non-rust wrapper that do not support this (like our ruby gem).