### PR TITLE
refactor: use hostname as user domain instead of WORKGROUP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ impl Cifs {
         let auth = maybe_auth.unwrap_or(Auth {
             user: String::new(),
             password: String::new(),
-            domain: "WORKGROUP".to_owned(),
+            domain: host.to_string(),
             workstation: "ANONYMOUS".to_owned(),
         });
 


### PR DESCRIPTION
After some issues with Windows 10 systems, I checked differences between our client and cURL (which still worked) and noticed that cURL uses the hostname when authenticating.